### PR TITLE
Add endpoints to add and delete pokemon attacks

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -67,6 +67,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.corundumstudio.socketio</groupId>
 			<artifactId>netty-socketio</artifactId>
 			<version>${netty-socketio.version}</version>

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/PokemonController.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/PokemonController.java
@@ -1,8 +1,7 @@
 package com.pokemonbattle.pokemonbattlebackend.pokemon;
-import com.pokemonbattle.pokemonbattlebackend.restApi.GlobalRestAPIErrorResponse;
-import com.pokemonbattle.pokemonbattlebackend.pokemon.exceptions.PokemonNotFoundException;
+import com.pokemonbattle.pokemonbattlebackend.pokemon.attack.AttackService;
+import com.pokemonbattle.pokemonbattlebackend.pokemon.attack.AttackWithMediaDTO;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -12,9 +11,11 @@ import java.util.List;
 public class PokemonController {
 
     private final PokemonService pokemonService;
+    private final AttackService attackService;
 
-    public PokemonController(PokemonService pokemonService) {
+    public PokemonController(PokemonService pokemonService, AttackService attackService) {
        this.pokemonService = pokemonService;
+       this.attackService = attackService;
     }
 
     @GetMapping("")
@@ -45,12 +46,16 @@ public class PokemonController {
         this.pokemonService.deletePokemon(id);
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{pokemonId}/attack/create")
+    void createAttacks(@PathVariable Long pokemonId, @RequestBody AttackWithMediaDTO attackWithMediaDTO) {
+        this.attackService.createAttack(pokemonId, attackWithMediaDTO);
+    }
 
-    @ExceptionHandler(PokemonNotFoundException.class)
-    public ResponseEntity<GlobalRestAPIErrorResponse> handlePokemonNotFoundException (Exception e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new GlobalRestAPIErrorResponse(
-                e.getMessage()
-        ));
-    };
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{pokemonId}/attack/{id}")
+    void deleteAttack(@PathVariable Long id) {
+        this.attackService.deleteAttack(id);
+    }
 
 }

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/PokemonService.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/PokemonService.java
@@ -14,18 +14,16 @@ import java.util.Optional;
 public class PokemonService {
 
        private final PokemonRepository pokemonRepository;
-    private final AttackRepository attackRepository;
 
-       public PokemonService(PokemonRepository pokemonRepository, AttackRepository attackRepository) {
+       public PokemonService(PokemonRepository pokemonRepository) {
            this.pokemonRepository = pokemonRepository;
-           this.attackRepository = attackRepository;
        }
 
        List<Pokemon> getAllPokemons() {
            return this.pokemonRepository.findAll();
        }
 
-       Pokemon getPokemonById(Long id) {
+       public Pokemon getPokemonById(Long id) {
            Optional<Pokemon> pokemon = this.pokemonRepository.findById(id);
 
            if (pokemon.isEmpty()) {

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/Attack.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/Attack.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pokemonbattle.pokemonbattlebackend.pokemon.Pokemon;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -38,6 +40,11 @@ public class Attack {
     @JsonProperty("energy_consumed")
     @Column(name = "energy_consumed", nullable = false)
     private Integer energyConsumed;
+
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("attack_alignment")
+    @Column(name = "attack_alignment", nullable = false)
+    private AttackAlignment attackAlignment;
 
 
     @Override

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackDTO.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackDTO.java
@@ -1,5 +1,6 @@
 package com.pokemonbattle.pokemonbattlebackend.pokemon.attack;
 
+import com.pokemonbattle.pokemonbattlebackend.pokemon.Pokemon;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ public class AttackDTO {
     private Integer power;
     private Integer accuracy;
     private Integer energyConsumed;
+    private AttackAlignment attackAlignment;
 
     public AttackDTO(Long pokemonId, Attack attack) {
         this.id = attack.getId();
@@ -21,6 +23,7 @@ public class AttackDTO {
         this.power = attack.getPower();
         this.accuracy = attack.getAccuracy();
         this.energyConsumed = attack.getEnergyConsumed();
+        this.attackAlignment = attack.getAttackAlignment();
     }
 
     public static List<AttackDTO> from(Long pokemonId, List<Attack> attacks) {

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackService.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackService.java
@@ -1,0 +1,33 @@
+package com.pokemonbattle.pokemonbattlebackend.pokemon.attack;
+
+import com.pokemonbattle.pokemonbattlebackend.pokemon.Pokemon;
+import com.pokemonbattle.pokemonbattlebackend.pokemon.PokemonRepository;
+import com.pokemonbattle.pokemonbattlebackend.pokemon.PokemonService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AttackService {
+
+    private final AttackRepository attackRepository;
+    private final PokemonService pokemonService;
+
+    public AttackService(AttackRepository attackRepository, PokemonService pokemonService) {
+        this.attackRepository = attackRepository;
+        this.pokemonService = pokemonService;
+    }
+
+    public void createAttack(Long pokemonId, AttackWithMediaDTO attackWithMediaDTO) {
+        Pokemon pokemon = this.pokemonService.getPokemonById(pokemonId);
+
+        Attack attackToBeCreated = AttackWithMediaDTO.createAttackEntityToSave(pokemon, attackWithMediaDTO);
+        this.attackRepository.save(attackToBeCreated);
+    }
+
+    public void deleteAttack(Long attackId) {
+        this.attackRepository.deleteById(attackId);
+    }
+
+
+}

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackWithMediaDTO.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/pokemon/attack/AttackWithMediaDTO.java
@@ -1,0 +1,47 @@
+package com.pokemonbattle.pokemonbattlebackend.pokemon.attack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pokemonbattle.pokemonbattlebackend.pokemon.Pokemon;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record AttackWithMediaDTO(
+         Pokemon pokemon,
+         @NotBlank(message = "Attack name is required")
+         String name,
+         @NotBlank(message = "Media is required")
+         @JsonProperty("media_src")
+         String mediaSrc,
+         @NotNull(message = "Power is required")
+         Integer power,
+         @NotNull(message = "Accuracy is required")
+         Integer accuracy,
+         @NotNull(message = "Energy consumed is required")
+         @JsonProperty("energy_consumed")
+         Integer energyConsumed,
+         @NotBlank(message = "Attack alignment is required")
+         @Enumerated(EnumType.STRING)
+         @JsonProperty("attack_alignment")
+         AttackAlignment attackAlignment
+) {
+
+    public static Attack createAttackEntityToSave(Pokemon pokemon, AttackWithMediaDTO attackWithMediaDTO){
+        Attack attack = new Attack();
+        attack.setPokemon(pokemon);
+        attack.setName(attackWithMediaDTO.name());
+        attack.setMediaSrc(attackWithMediaDTO.mediaSrc());
+        attack.setPower(attackWithMediaDTO.power());
+        attack.setAccuracy(attackWithMediaDTO.accuracy());
+        attack.setEnergyConsumed(attackWithMediaDTO.energyConsumed());
+        attack.setAttackAlignment(attackWithMediaDTO.attackAlignment());
+
+        return attack;
+    }
+
+}

--- a/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/restApi/GlobalRestAPIExceptionHandler.java
+++ b/backend/src/main/java/com/pokemonbattle/pokemonbattlebackend/restApi/GlobalRestAPIExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.pokemonbattle.pokemonbattlebackend.restApi;
 
+import com.pokemonbattle.pokemonbattlebackend.pokemon.exceptions.PokemonNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +14,13 @@ public class GlobalRestAPIExceptionHandler extends ResponseEntityExceptionHandle
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleRuntimeException (Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new GlobalRestAPIErrorResponse("An unexpected error occurred."));
+    };
+
+    @ExceptionHandler(PokemonNotFoundException.class)
+    public ResponseEntity<GlobalRestAPIErrorResponse> handlePokemonNotFoundException (Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new GlobalRestAPIErrorResponse(
+                e.getMessage()
+        ));
     };
 
 }


### PR DESCRIPTION
Acceptance criteria:
- On sending attack json data with pokemon id in POST request, attack should be stored and mapped to the associated pokemon.
- On sending attack id in DELETE request, attack data should be removed from DB. 